### PR TITLE
Update Quick Start step 4 to emphasize reading command details before calling

### DIFF
--- a/skills/flyai/SKILL.md
+++ b/skills/flyai/SKILL.md
@@ -42,7 +42,7 @@ All commands output **single-line JSON** to `stdout`; errors and hints go to `st
 1. **Install CLI**：`npm i -g @fly-ai/flyai-cli`
 2. **Verify setup**: run `flyai fliggy-fast-search --query "what to do in Sanya"` and confirm JSON output.
 3. **List commands**: run `flyai --help`.
-4. **Read command details BEFORE calling**: always check the corresponding file in `references/` before invoking any command. Do NOT guess or reuse formats from other commands.
+4. **Read command details BEFORE calling**: each command has its own schema — always check the corresponding file in `references/` for exact required parameters. Do NOT guess or reuse formats from other commands.
 
 ## Configuration
 The tool can make trial without any API keys. For enhanced results, configure optional APIs:


### PR DESCRIPTION
This PR updates the Quick Start step 4 in SKILL.md to emphasize the importance of reading command details before invoking any command.

## Background

During skill usage, we observed a common issue: **agents often execute commands first and read the reference documentation afterwards**. For example, when using `search-flight`, the agent would run the command with incorrect or fabricated parameters before checking `references/search-flight.md` to understand the required parameter format. This leads to unnecessary errors, retries, and poor user experience.

## Changes

Updated step 4 from a brief reference to a detailed instruction that emphasizes:
- **MUST** read the corresponding file in `references/` **BEFORE** invoking any command
- Extract exact required parameters from the reference doc
- Do **NOT** guess parameter values
- Do **NOT** reuse parameter formats from other commands — each command has its own schema

This change aims to prevent agents from fabricating command parameters and encourage proper reference documentation review before execution.