### PR TITLE
Update SKILL.md

### DIFF
--- a/skills/flyai/SKILL.md
+++ b/skills/flyai/SKILL.md
@@ -44,13 +44,6 @@ All commands output **single-line JSON** to `stdout`; errors and hints go to `st
 3. **List commands**: run `flyai --help`.
 4. **Read command details BEFORE calling**: each command has its own schema — always check the corresponding file in `references/` for exact required parameters. Do NOT guess or reuse formats from other commands.
 
-## Configuration
-The tool can make trial without any API keys. For enhanced results, configure optional APIs:
-
-```
-flyai config set FLYAI_API_KEY "your-key"
-```
-
 ## Core Capabilities
 
 ### Time and context support


### PR DESCRIPTION
## Description

  This PR removes the "Configuration" section from SKILL.md that references an API Key configuration option (`FLYAI_API_KEY`) which appears to have no clear acquisition path for users.

  ## Problem

  Users are confused by the documentation mentioning `flyai config set FLYAI_API_KEY "your-key"` because:
  1. The API Key acquisition入口 is not clearly visible on https://open.fly.ai/
  2. The website only says "visit the China site to log in and retrieve your authorized API Key" without a clear button or link
  3. This creates a poor user experience where documentation references a feature that is hard to access

  ## Changes

  - Removed the "Configuration" section (lines 47-52) from `skills/flyai/SKILL.md`
  - The tool can still be used without API Key for basic functionality as documented in Quick Start

  ## Impact

  - Documentation is now clearer for new users
  - No functional changes to the CLI or skill behavior
  - Users who do have API Key access can still use it (undocumented feature remains functional)